### PR TITLE
Update Flask-OAuthlib to 0.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 Flask==0.10.1
 Flask-Login==0.2.10
 Flask-Migrate==1.2.0
-Flask-OAuthlib==0.6.0
+Flask-OAuthlib==0.7.0
 Flask-SQLAlchemy==1.0
 Flask-Script==2.0.5
 Flask-WTF==0.9.4


### PR DESCRIPTION
The correct version was written in the setup.py (Flask-OAuthlib>=0.7.0) but the requirements.txt was at 0.6.0 which does not work with the current OAuth code and notably the authorized_response/handler as seen [here](https://flask-oauthlib.readthedocs.org/en/latest/api.html#flask_oauthlib.client.OAuthRemoteApp.authorized_handler).

Enjoy!
